### PR TITLE
Fix problems with update button

### DIFF
--- a/launchpad-reporting/main.py
+++ b/launchpad-reporting/main.py
@@ -25,7 +25,7 @@ prs = db.projects.find_one()["Project"]
 
 subprs = db.subprojects.find_one()["Subproject"]
 
-key_milestone = "5.1"
+key_milestone = "6.0"
 
 all_tags = ""
 for s in subprs:
@@ -116,8 +116,8 @@ def code_freeze_report(milestone_name):
     teams = ["Fuel", "Partners", "mos-linux", "mos-openstack"]
     exclude_tags = ["devops", "docs", "fuel-devops", "experimental"]
 
-    if milestone_name == "5.1" or milestone_name == "5.0.2":
-        milestone = ["5.1", "5.0.2"]
+    if milestone_name == "6.0":
+        milestone = ["6.0"]
         bugs = lpdata.code_freeze_statistic(milestone=milestone,
                                             teams=teams,
                                             exclude_tags=exclude_tags)

--- a/launchpad-reporting/templates/code_freeze_report.html
+++ b/launchpad-reporting/templates/code_freeze_report.html
@@ -13,6 +13,14 @@
     </ul>
     {% endif %}
     {% endfor %}
+    
+    <ul class="nav nav-sidebar">
+
+        <li>
+            <a href="/project/code_freeze_report/{{ key_milestone }}">MOS HCF Status
+            </a>
+        </li>
+    </ul>
 </div>
 
 {% for team in teams %}

--- a/launchpad-reporting/templates/layout.html
+++ b/launchpad-reporting/templates/layout.html
@@ -53,12 +53,11 @@
 
       <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
       <div class="container-fluid">
-          <img src="http://www.mirantis.com/id/RasterMirantisLogo_HiRes_Tagline_Inverted.png" width="4%" align="left" alt="Mirantis Logo">
+          <img src="http://www.mirantis.com/id/RasterMirantisLogo_HiRes_Tagline_Inverted.png" width="3%" align="left" alt="Mirantis Logo">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">Launchpad Bugs Summary Reports</a>
           <a class="navbar-brand" href=""></a>
           <a class="navbar-brand" href="/project/fuelplusmos/{{ key_milestone }}">FUEL+MOS</a>
-          <a class="navbar-brand" href="/project/code_freeze_report/{{ key_milestone }}">MOS HCF Status</a>
           {% for p in prs %}
              {% if p in ("fuel", "mos")%}
                 <a class="navbar-brand" href="/project/{{ p }}"><p><font style="text-transform:  uppercase;">{{ p }}</font></p></a>

--- a/launchpad-reporting/templates/project_fuelmos.html
+++ b/launchpad-reporting/templates/project_fuelmos.html
@@ -14,6 +14,13 @@
     </ul>
 
     {% endfor %}
+    <ul class="nav nav-sidebar">
+
+        <li>
+            <a href="/project/code_freeze_report/{{ key_milestone }}">MOS HCF Status
+            </a>
+        </li>
+    </ul>
 </div>
 
 


### PR DESCRIPTION
Transfer "MOS HCF" button in left side-bar and changes key_milestone
from 5.1 to 6.0. Because of this transfer button "UPDATE status" not
longer overlaps on left side-bar.
