### PR TITLE
Fixes to make `Getting Started` instruction actual

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,32 @@ Getting Started
 ===============
 
 ```
-First, install pip and virtualenv on your system. On Ubuntu it can be done by running "sudo apt-get install python-pip python-virtualenv". You may also consider using virtualenvwrapper script (http://virtualenvwrapper.readthedocs.org/en/latest/). Also you will need to install mongodb. Then:
+First, install pip and virtualenv on your system. On Ubuntu it can be done by
+running "sudo apt-get install python-pip python-virtualenv". You may also
+consider using virtualenvwrapper script (http://virtualenvwrapper.readthedocs.org/en/latest/).
+Also you will need to install mongodb.
+Please, note, that launchpad-reporting connects to launchpad, which requires
+oauth authorization. Setting this up usually requires a web browser, and some
+users have experience trouble with console browsers such as lynx. Therefore,
+you may also want to run the following commands on your local system where a
+regular GUI browser is available, instead of on a remote server where only the
+terminal is available to you.
+Also launchpad-reporting stores creds in the `/etc/lp-reports/credentials.txt`
+file, so you must ensure, that this path exists and launchpad-reporting have
+enough permissions to create/read/modify `credentials.txt` file.
+Then:
 
 ~$ virtualenv venv  # creating virtualenv
 ~$ source venv/bin/activate
 ~$ git clone https://github.com/Mirantis/launchpad-reports-summary.git
 ~$ cd launchpad-reports-summary
 ~$ mkdir data  # folder to store mongodb data (you can specify your own)
-~$ mongod --dbpath ./data  # this launches mongodb instance. It may take some time first
+~$ mongod --dbpath ./data  # this launches mongodb instance. It may take some
+                           # time first
 ~$ pip install -r requirements.txt
 ~$ python syncdb.py
 ~$ python collect_assignees.py
-~$ python main.py run
+~$ python main.py run --port=1111
 ```
 
 After that, open http://localhost:1111 in your browser.


### PR DESCRIPTION
`credentials_file` parameter is optional for Launchpad.login_with() so
there is no big sense to hard-code it

Minor fixes in the `Getting Started` instruction
