### PR TITLE
Remove non-actual info after target project changing

### DIFF
--- a/launchpad_reporting/launchpad/lpdata.py
+++ b/launchpad_reporting/launchpad/lpdata.py
@@ -94,6 +94,14 @@ class LaunchpadData(object):
                                    modified_since=update_time,
                                    omit_duplicates=False)
 
+    @ttl_cache(minutes=5)
+    def get_bug_targets(self, bug):
+        targets = set()
+        targets.add(bug.bug_target_name.split('/')[0])
+        for task in bug.related_tasks:
+            targets.add(task.bug_target_name.split('/')[0])
+        return targets
+
     @staticmethod
     def dump_object(object):
         for name in dir(object):

--- a/syncdb.py
+++ b/syncdb.py
@@ -163,12 +163,19 @@ def load_project_bugs(project_name, queue, stop_event):
 
     counter = 0
     for bug in launchpad.get_all_bugs(project):
+        bug_id = bug.bug.id
         db.bugs[
             str(bug.bug_target_name).split('/')[0]
-        ].remove({'id': bug.bug.id})
+        ].remove({'id': bug_id})
 
         if bug.bug.duplicate_of is not None:
             continue
+
+        target_projects = launchpad.get_bug_targets(bug)
+
+        for project in PROJECTS_LIST:
+            if project not in target_projects:
+                db.bugs[project].remove({'id': bug_id})
 
         bug_milestone = str(bug.milestone)
         rts = bug.related_tasks.entries


### PR DESCRIPTION
Remove bug from all projects in db that are not in target
projects of the bug.

https://bugs.launchpad.net/summary-reports/+bug/1400655
