### PR TITLE
Fix `KeyError` exception, during syncdb.py run

### DIFF
--- a/syncdb.py
+++ b/syncdb.py
@@ -186,7 +186,7 @@ def load_project_bugs(project_name, queue, stop_event):
         related_tasks_milestones = [rt["target_link"] for rt in related_tasks]
 
         if related_tasks:
-            if milestone_series[bug_milestone] not in related_tasks_milestones:
+            if milestone_series.get(bug_milestone) not in related_tasks_milestones:
                 queue.put(serialize_bug(bug))
 
             for rt in related_tasks:


### PR DESCRIPTION
When we get all bugs from launchpad, we do not filter them by the
milestone anymore, so we can get also bugs, with non-active milestones.
Then, when we trying to get this milestone  from the `milestone_series`
dictionary (which was formed from the active_milestones only) we get
`KeyError` exception.

To fix it, replaced ``milestone_series[bug_milestone]`` to
``milestone_series.get(bug_milestone)``. So if milestone not in active
milestones, this will return None as value. None not in
related_tasks_milestones list, so we will skip this bug and proceed the
next one.