### PR TITLE
Fix date select

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -24,6 +24,16 @@
 
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
+        <!-- cdn for modernizr, if you haven't included it already -->
+        <script src="http://cdn.jsdelivr.net/webshim/1.12.4/extras/modernizr-custom.js"></script>
+        <!-- polyfiller file to detect and load polyfills -->
+        <script src="http://cdn.jsdelivr.net/webshim/1.12.4/polyfiller.js"></script>
+        <script>
+          webshims.setOptions('waitReady', false);
+          webshims.setOptions('forms-ext', {types: 'date'});
+          webshims.polyfill('forms forms-ext');
+        </script>
+
         <script src="/static/jquery/jquery.min.js"></script>
         <script>
             $(function() {


### PR DESCRIPTION
We have several places in our html where we use type="date" which
were added in html5. Unfortunately, some browsers don't fully support
html5 spec. Use js for html5 compliance.